### PR TITLE
handle encoding in HTTP Content-Type header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,10 @@
 
 # Build results
 [Dd]ebug/
+Debug-UTF8/
 [Dd]ebugPublic/
 [Rr]elease/
+Release-UTF8/
 x64/
 build/
 bld/
@@ -139,6 +141,9 @@ csx/
 AppPackages/
 
 # Others
+.idea/
+.vs/
+.vscode/
 sql/
 *.Cache
 ClientBin/

--- a/src/litebrowser.vcxproj
+++ b/src/litebrowser.vcxproj
@@ -136,8 +136,8 @@
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-UTF8|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug-UTF8|x64'">
@@ -146,8 +146,8 @@
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-UTF8|Win32'">
-    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
-    <IntDir>$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release-UTF8|x64'">

--- a/src/web_page.cpp
+++ b/src/web_page.cpp
@@ -223,7 +223,7 @@ void web_page::load( LPCWSTR url )
 		m_http.download_file( url, new web_file(this, web_file_document) );
 	} else
 	{
-		on_document_loaded(url, L"UTF-8", NULL);
+		on_document_loaded(url, NULL, NULL);
 	}
 }
 
@@ -235,7 +235,7 @@ void web_page::on_document_loaded(LPCWSTR file, LPCWSTR encoding, LPCWSTR realUr
 	}
 
 #ifdef LITEHTML_UTF8
-	litehtml::byte* html_text = load_utf8_file(file, true);
+	litehtml::byte* html_text = load_utf8_file(file, true, L"UTF-8", encoding);
 
 	if(!html_text)
 	{
@@ -247,7 +247,7 @@ void web_page::on_document_loaded(LPCWSTR file, LPCWSTR encoding, LPCWSTR realUr
 	m_doc = litehtml::document::createFromUTF8((const char*) html_text, this, m_parent->get_html_context());
 	delete html_text;
 #else
-	LPWSTR html_text = load_text_file(file, true, encoding);
+	LPWSTR html_text = load_text_file(file, true, L"UTF-8", encoding);
 
 	if(!html_text)
 	{
@@ -263,9 +263,9 @@ void web_page::on_document_loaded(LPCWSTR file, LPCWSTR encoding, LPCWSTR realUr
 	PostMessage(m_parent->wnd(), WM_PAGE_LOADED, 0, 0);
 }
 
-LPWSTR web_page::load_text_file( LPCWSTR path, bool is_html, LPCWSTR defEncoding )
+LPWSTR web_page::load_text_file(LPCWSTR path, bool is_html, LPCWSTR defEncoding, LPCWSTR forceEncoding)
 {
-	char* utf8 = (char*) load_utf8_file(path, is_html, defEncoding);
+	char* utf8 = (char*) load_utf8_file(path, is_html, defEncoding, forceEncoding);
 
 	if(utf8)
 	{
@@ -385,7 +385,7 @@ void web_page::get_url( std::wstring& url )
 	}
 }
 
-unsigned char* web_page::load_utf8_file( LPCWSTR path, bool is_html, LPCWSTR defEncoding )
+unsigned char* web_page::load_utf8_file(LPCWSTR path, bool is_html, LPCWSTR defEncoding, LPCWSTR forceEncoding)
 {
 	unsigned char* ret = NULL;
 
@@ -416,37 +416,44 @@ unsigned char* web_page::load_utf8_file( LPCWSTR path, bool is_html, LPCWSTR def
 	if(is_html)
 	{
 		std::wstring encoding;
-		char* begin = StrStrIA((LPSTR) ret, "<meta");
-		while(begin && encoding.empty())
+		if (forceEncoding)
 		{
-			char* end = StrStrIA(begin, ">");
-			char* s1 = StrStrIA(begin, "Content-Type");
-			if(s1 && s1 < end)
+			encoding = forceEncoding;
+		}
+		else
+		{
+			char* begin = StrStrIA((LPSTR)ret, "<meta");
+			while (begin && encoding.empty())
 			{
-				s1 = StrStrIA(begin, "charset");
-				if(s1)
+				char* end = StrStrIA(begin, ">");
+				char* s1 = StrStrIA(begin, "Content-Type");
+				if (s1 && s1 < end)
 				{
-					s1 += strlen("charset");
-					while(!isalnum(s1[0]) && s1 < end)
+					s1 = StrStrIA(begin, "charset");
+					if (s1)
 					{
-						s1++;
-					}
-					while((isalnum(s1[0]) || s1[0] == '-') && s1 < end)
-					{
-						encoding += s1[0];
-						s1++;
+						s1 += strlen("charset");
+						while (!isalnum(s1[0]) && s1 < end)
+						{
+							s1++;
+						}
+						while ((isalnum(s1[0]) || s1[0] == '-') && s1 < end)
+						{
+							encoding += s1[0];
+							s1++;
+						}
 					}
 				}
+				if (encoding.empty())
+				{
+					begin = StrStrIA(begin + strlen("<meta"), "<meta");
+				}
 			}
-			if(encoding.empty())
-			{
-				begin = StrStrIA(begin + strlen("<meta"), "<meta");
-			}
-		}
 
-		if(encoding.empty() && defEncoding)
-		{
-			encoding = defEncoding;
+			if (encoding.empty() && defEncoding)
+			{
+				encoding = defEncoding;
+			}
 		}
 
 		if(!encoding.empty())
@@ -551,7 +558,7 @@ void web_file::OnFinish( DWORD dwError, LPCWSTR errMsg )
 		switch(m_type)
 		{
 		case web_file_document:
-			m_page->on_document_loaded(m_file, L"UTF-8", m_realUrl.empty() ? NULL : m_realUrl.c_str());
+			m_page->on_document_loaded(m_file, m_encoding.empty() ? NULL : m_encoding.c_str(), m_realUrl.empty() ? NULL : m_realUrl.c_str());
 			break;
 		case web_file_image_redraw:
 			m_page->on_image_loaded(m_file, m_url.c_str(), true);
@@ -582,5 +589,14 @@ void web_file::OnHeadersReady( HINTERNET hRequest )
 	if (WinHttpQueryOption(m_hRequest, WINHTTP_OPTION_URL, buf, &len))
 	{
 		m_realUrl = buf;
+	}
+	len = sizeof(buf);
+	if (WinHttpQueryHeaders(m_hRequest, WINHTTP_QUERY_CONTENT_TYPE, NULL, buf, &len, NULL))
+	{
+		WCHAR* pos = wcsstr(buf, L"charset=");
+		if (pos)
+		{
+			m_encoding = pos + wcslen(L"charset=");
+		}
 	}
 }

--- a/src/web_page.cpp
+++ b/src/web_page.cpp
@@ -157,7 +157,7 @@ void web_page::import_css( litehtml::tstring& text, const litehtml::tstring& url
 			delete css;
 		}
 #else
-		LPSTR css = (LPSTR) load_utf8_file(m_waited_file.c_str(), false, L"UTF-8");
+		LPSTR css = load_utf8_file(m_waited_file.c_str(), false, L"UTF-8");
 		if(css)
 		{
 			LPSTR css_urlA = cairo_font::wchar_to_utf8(css_url.c_str());
@@ -234,38 +234,24 @@ void web_page::on_document_loaded(LPCWSTR file, LPCWSTR encoding, LPCWSTR realUr
 		m_url = realUrl;
 	}
 
-#ifdef LITEHTML_UTF8
-	litehtml::byte* html_text = load_utf8_file(file, true, L"UTF-8", encoding);
+	char* html_text = load_utf8_file(file, true, L"UTF-8", encoding);
 
 	if(!html_text)
 	{
 		LPCSTR txt = "<h1>Something Wrong</h1>";
-		html_text = new litehtml::byte[lstrlenA(txt) + 1];
-		lstrcpyA((LPSTR) html_text, txt);
+		html_text = new char[lstrlenA(txt) + 1];
+		lstrcpyA(html_text, txt);
 	}
 
-	m_doc = litehtml::document::createFromUTF8((const char*) html_text, this, m_parent->get_html_context());
+	m_doc = litehtml::document::createFromUTF8(html_text, this, m_parent->get_html_context());
 	delete html_text;
-#else
-	LPWSTR html_text = load_text_file(file, true, L"UTF-8", encoding);
-
-	if(!html_text)
-	{
-		LPCWSTR txt = L"<h1>Something Wrong</h1>";
-		html_text = new WCHAR[lstrlen(txt) + 1];
-		lstrcpy(html_text, txt);
-	}
-
-	m_doc = litehtml::document::createFromString(html_text, this, m_parent->get_html_context());
-	delete html_text;
-#endif
 
 	PostMessage(m_parent->wnd(), WM_PAGE_LOADED, 0, 0);
 }
 
 LPWSTR web_page::load_text_file(LPCWSTR path, bool is_html, LPCWSTR defEncoding, LPCWSTR forceEncoding)
 {
-	char* utf8 = (char*) load_utf8_file(path, is_html, defEncoding, forceEncoding);
+	char* utf8 = load_utf8_file(path, is_html, defEncoding, forceEncoding);
 
 	if(utf8)
 	{
@@ -385,15 +371,15 @@ void web_page::get_url( std::wstring& url )
 	}
 }
 
-unsigned char* web_page::load_utf8_file(LPCWSTR path, bool is_html, LPCWSTR defEncoding, LPCWSTR forceEncoding)
+char* web_page::load_utf8_file(LPCWSTR path, bool is_html, LPCWSTR defEncoding, LPCWSTR forceEncoding)
 {
-	unsigned char* ret = NULL;
+	char* ret = NULL;
 
 	HANDLE fl = CreateFile(path, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 	if(fl != INVALID_HANDLE_VALUE)
 	{
 		DWORD size = GetFileSize(fl, NULL);
-		ret = new unsigned char[size + 1];
+		ret = new char[size + 1];
 
 		DWORD cbRead = 0;
 		if(size >= 3)
@@ -490,7 +476,7 @@ unsigned char* web_page::load_utf8_file(LPCWSTR path, bool is_html, LPCWSTR defE
 			{
 				dst[szDst] = 0;
 				delete ret;
-				ret = (unsigned char*) dst;
+				ret = dst;
 			} else
 			{
 				delete dst;

--- a/src/web_page.h
+++ b/src/web_page.h
@@ -47,7 +47,7 @@ public:
 	virtual void		get_client_rect(litehtml::position& client)  const;
 private:
 	LPWSTR	load_text_file(LPCWSTR path, bool is_html, LPCWSTR defEncoding = L"UTF-8", LPCWSTR forceEncoding = NULL);
-	unsigned char*	load_utf8_file(LPCWSTR path, bool is_html, LPCWSTR defEncoding = L"UTF-8", LPCWSTR forceEncoding = NULL);
+	char*	load_utf8_file(LPCWSTR path, bool is_html, LPCWSTR defEncoding = L"UTF-8", LPCWSTR forceEncoding = NULL);
 	BOOL	download_and_wait(LPCWSTR url);
 };
 

--- a/src/web_page.h
+++ b/src/web_page.h
@@ -25,6 +25,8 @@ public:
 	virtual ~web_page();
 
 	void load(LPCWSTR url);
+	// encoding: as specified in Content-Type HTTP header
+	//   it is NULL for local files or if Content-Type header is not present or Content-Type header doesn't contain "charset="
 	void on_document_loaded(LPCWSTR file, LPCWSTR encoding, LPCWSTR realUrl);
 	void on_image_loaded(LPCWSTR file, LPCWSTR url, bool redraw_only);
 	void on_document_error(DWORD dwError, LPCWSTR errMsg);
@@ -44,8 +46,8 @@ public:
 	virtual cairo_container::image_ptr	get_image(LPCWSTR url, bool redraw_on_ready);
 	virtual void		get_client_rect(litehtml::position& client)  const;
 private:
-	LPWSTR	load_text_file( LPCWSTR path, bool is_html, LPCWSTR defEncoding = L"UTF-8");
-	unsigned char*	load_utf8_file( LPCWSTR path, bool is_html, LPCWSTR defEncoding = L"UTF-8");
+	LPWSTR	load_text_file(LPCWSTR path, bool is_html, LPCWSTR defEncoding = L"UTF-8", LPCWSTR forceEncoding = NULL);
+	unsigned char*	load_utf8_file(LPCWSTR path, bool is_html, LPCWSTR defEncoding = L"UTF-8", LPCWSTR forceEncoding = NULL);
 	BOOL	download_and_wait(LPCWSTR url);
 };
 
@@ -65,6 +67,7 @@ class web_file : public tordex::http_request
 	HANDLE			m_hFile;
 	LPVOID			m_data;
 	std::wstring	m_realUrl;
+	std::wstring	m_encoding;
 public:
 	web_file(web_page* page, web_file_type type, LPVOID data = NULL);
 	virtual ~web_file();


### PR DESCRIPTION
This PR fixes [this page](http://az.lib.ru/t/tolstoj_lew_nikolaewich/text_0080.shtml), which specifies encoding only in HTTP header.
Encoding in Content-Type HTTP header takes precedence over `<meta>`.
`web_page::on_document_loaded` parameter `encoding` is now a forced encoding (comes from HTTP header),
not the default encoding.

<hr>

Refactor in `web_page::on_document_loaded`: the `#ifdef LITEHTML_UTF8` block works regardless of `LITEHTML_UTF8`, so I removed the `#else` block.